### PR TITLE
bugfix backward-incompatible: rename role name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 node ('virtualbox') {
 
-  def directory = "ansible-role-x509-certificate"
+  def directory = "ansible-role-x509_certificate"
   env.ANSIBLE_VAULT_PASSWORD_FILE = "~/.ansible_vault_key"
   stage 'Clean up'
   deleteDir()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ansible-role-x509-certificate
+# ansible-role-x509_certificate
 
 Manages X509 secret and/or public keys. The role assumes you already have valid
 secret key or *signed* public key. The role does not create or manage CSR.
@@ -100,7 +100,7 @@ None
 ```yaml
 - hosts: localhost
   roles:
-    - ansible-role-x509-certificate
+    - ansible-role-x509_certificate
   vars:
     # XXX NEVER set this variable to `yes` unless you know what you are doing.
     x509_certificate_debug_log: yes

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Restart x509-certificate
+- name: Restart x509_certificate
   service:
-    name: x509-certificate
+    name: x509_certificate
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# tasks file for ansible-role-x509-certificate
+# tasks file for ansible-role-x509_certificate
 
 - include_vars: "{{ ansible_os_family }}.yml"
 

--- a/tests/integration/example/client
+++ b/tests/integration/example/client
@@ -9,4 +9,4 @@
 
   pre_tasks:
   roles:
-    - x509-certificate
+    - x509_certificate

--- a/tests/integration/example/example.yml
+++ b/tests/integration/example/example.yml
@@ -9,4 +9,4 @@
 
   pre_tasks:
   roles:
-    - x509-certificate
+    - x509_certificate

--- a/tests/integration/example/server.yml
+++ b/tests/integration/example/server.yml
@@ -9,4 +9,4 @@
 
   pre_tasks:
   roles:
-    - x509-certificate
+    - x509_certificate

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -1,6 +1,6 @@
 - hosts: localhost
   roles:
-    - ansible-role-x509-certificate
+    - ansible-role-x509_certificate
   vars:
     # XXX NEVER set this variable to `yes` unless you know what you are doing.
     x509_certificate_debug_log: yes

--- a/tests/travisci/tests.yml
+++ b/tests/travisci/tests.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ansible-role-x509-certificate
+    - ansible-role-x509_certificate


### PR DESCRIPTION
galaxy has introduced breaking change in import process. `role_name` in
meta/main.yml is now deprecated, and dash in role name is replaced with
underscore during the import process. this has already broken CI process
and deployments.