### PR TITLE
[bugfix] fixed wrong variable used for default path for certificate deletions

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
 
 - name: Remove public keys
   file:
-    path: "{{ item.public.path | default(x509_certificate_present + '/' + item.name + '.pub') }}"
+    path: "{{ item.public.path | default(x509_certificate_dir + '/' + item.name + '.pub') }}"
     state: absent
   no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_absent }}"
@@ -84,7 +84,7 @@
 
 - name: Remove secret keys
   file:
-    path: "{{ item.secret.path | default(x509_certificate_present + '/' + item.name + '.pub') }}"
+    path: "{{ item.secret.path | default(x509_certificate_dir + '/' + item.name + '.pub') }}"
     state: absent
   no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_absent }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,7 +75,7 @@
 
 - name: Remove public keys
   file:
-    path: "{{ item.public.path | default(x509_certificate_dir + '/' + item.name + '.pub') }}"
+    path: "{{ item.public.path | default(x509_certificate_dir + '/' + item.name + '.pem') }}"
     state: absent
   no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_absent }}"
@@ -84,7 +84,7 @@
 
 - name: Remove secret keys
   file:
-    path: "{{ item.secret.path | default(x509_certificate_dir + '/' + item.name + '.pub') }}"
+    path: "{{ item.secret.path | default(x509_certificate_dir + '/' + item.name + '.key') }}"
     state: absent
   no_log: "{% if x509_certificate_debug_log %}no{% else %}yes{% endif %}"
   with_items: "{{ x509_certificate_absent }}"


### PR DESCRIPTION
If you don't set a explicit path to delete a certificate, the Ansible run will fail. A variable used inside the default filter used for the path was wrong.
I think this was only a small typo :)